### PR TITLE
feat(warp): add Techbase theme for Warp terminal

### DIFF
--- a/extra/warp/techbase.yaml
+++ b/extra/warp/techbase.yaml
@@ -1,0 +1,26 @@
+name: Techbase 
+accent: '#5DCD9A'
+cursor: '#5DCD9A'
+background: '#191d23'
+foreground: '#CCD5E5'
+details: darker
+terminal_colors:
+  bright:
+    black: '#474B65'
+    blue: '#6A8BE3'
+    cyan: '#5DCD9A'
+    green: '#0EC256'
+    magenta: '#D6DDEA'
+    red: '#FFC0C5'
+    white: '#D6DDEA'
+    yellow: '#FFA630'
+  normal:
+    black: '#191d23'
+    blue: '#A9B9EF'
+    cyan: '#1A8C9B'
+    green: '#74BAA8'
+    magenta: '#BCB6EC'
+    red: '#F71735'
+    white: '#CCD5E5'
+    yellow: '#E9B872'
+


### PR DESCRIPTION
- Add techbase.yaml theme configuration for Warp terminal
- Includes complete color palette with normal and bright variants
- Matches existing Techbase colorscheme design
- Supports accent, cursor, background, and foreground colors