### PR TITLE
feat: added wezterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,6 @@ Matching color schemes are available for external tools:
 - Kitty
 - Tmux
 - Warp
+- Wezterm
 
 Please see those tools' respective documentation for how to use these configurations.

--- a/extra/wezterm/techbase.toml
+++ b/extra/wezterm/techbase.toml
@@ -1,0 +1,40 @@
+[metadata]
+name = "techbase"
+author = "Mcauley Penney (https://github.com/mcauley-penney)"
+origin_url = "https://github.com/mcauley-penney/techbase.nvim"
+aliases = []
+
+[colors]
+
+background = "#191d23"
+foreground = "#ccd5e5"
+
+cursor_bg = "#5dcd9a"
+cursor_border = "#5dcd9a"
+cursor_fg = "#ccd5e5"
+selection_bg = "#1f242d"
+selection_fg = "#ccd5e5"
+
+split = "#1a8c9b"
+
+ansi = [
+	"#191d23",
+	"#f71735",
+	"#74baa8",
+	"#e9b872",
+	"#a9b9ef",
+	"#bcb6ec",
+	"#1a8c9b",
+	"#ccd5e5",
+]
+
+brights = [
+	"#474b65",
+	"#ffc0c5",
+	"#0ec256",
+	"#ffa630",
+	"#6a8be3",
+	"#d6ddea",
+	"#5dcd9a",
+	"#d6ddea",
+]


### PR DESCRIPTION
Added wezterm colorscheme.
Users just need to put the in the colors directory (`~/.config/wezterm/colors/techbase.toml` on Linux), and then can say `config.color_scheme = "techbase"`.